### PR TITLE
[mvn] Fixing broken dependency on thymeleaf.

### DIFF
--- a/server/api/pom.xml
+++ b/server/api/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.thymeleaf</groupId>
                 <artifactId>thymeleaf-spring3</artifactId>
-                <version>1.1.3-SNAPSHOT</version>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
                 <groupId>org.cloudfoundry</groupId>


### PR DESCRIPTION
An error occurs when the `mvn compile` command is running.

The 1.1.3-SNAPSHOT version of the org.thymeleaf:thymeleaf-spring3 artifact
could not be found in the milestone (http://maven.springframework.org/milestone)
repository.

The artifact's version has been changed to the 1.1.4 one.

This problem is now fixed with this change.
