### PR TITLE
URL Cleanup

### DIFF
--- a/server/api/build.gradle
+++ b/server/api/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 repositories {
-    mavenRepo urls: 'http://repo.springsource.org/libs-snapshot'
+    mavenRepo urls: 'https://repo.springsource.org/libs-snapshot'
     mavenCentral()
 }
 

--- a/server/api/pom.xml
+++ b/server/api/pom.xml
@@ -209,15 +209,15 @@
     <repositories>
         <repository>
             <id>milestone</id>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
         <repository>
             <id>release</id>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>snapshot</id>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
         </repository>
         <repository>
             <id>sonatype-nexus-snapshots</id>

--- a/server/oauth/build.gradle
+++ b/server/oauth/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 repositories {
-    mavenRepo urls: 'http://maven.springframework.org/release'
-    mavenRepo urls: 'http://maven.springframework.org/milestone'
-    mavenRepo urls: 'http://maven.springframework.org/snapshot'
+    mavenRepo urls: 'https://maven.springframework.org/release'
+    mavenRepo urls: 'https://maven.springframework.org/milestone'
+    mavenRepo urls: 'https://maven.springframework.org/snapshot'
     mavenCentral()
     mavenLocal()
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance