### PR TITLE
URL Cleanup

### DIFF
--- a/client/android/res/xml/phonegap.xml
+++ b/client/android/res/xml/phonegap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phonegap>
-    <access origin="http://10.0.2.2:8080*"/>
-    <access origin="http://debug.phonegap.com*"/>
-    <access origin="http://html5expense-api.cloudfoundry.com*"/>
-    <access origin="http://haboauth.cloudfoundry.com*"/>
+    <access origin="https://10.0.2.2:8080*"/>
+    <access origin="https://debug.phonegap.com*"/>
+    <access origin="https://html5expense-api.cloudfoundry.com*"/>
+    <access origin="https://haboauth.cloudfoundry.com*"/>
 </phonegap>

--- a/server/api/pom.xml
+++ b/server/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -209,15 +209,15 @@
     <repositories>
         <repository>
             <id>milestone</id>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
         <repository>
             <id>release</id>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>snapshot</id>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
         </repository>
         <repository>
             <id>sonatype-nexus-snapshots</id>

--- a/server/api/src/main/resources/ec-loader.xml
+++ b/server/api/src/main/resources/ec-loader.xml
@@ -3,10 +3,10 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:batch="http://www.springframework.org/schema/batch"
        xmlns:integration="http://www.springframework.org/schema/integration"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	    http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	    http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd"
         >
 
     <!--<batch:job-repository id="jobRepository"-->

--- a/server/api/src/main/resources/oauth.xml
+++ b/server/api/src/main/resources/oauth.xml
@@ -3,8 +3,8 @@
              xmlns:beans="http://www.springframework.org/schema/beans"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="
-             http://www.springframework.org/schema/security/oauth2 http://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd
-             http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+             http://www.springframework.org/schema/security/oauth2 https://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd
+             http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
     <resource-server id="resourceServerFilter" resource-id="reports" token-services-ref="tokenServices" />
 

--- a/server/api/src/main/resources/security.xml
+++ b/server/api/src/main/resources/security.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <beans:beans xmlns="http://www.springframework.org/schema/security"
              xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+             xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-3.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
     <http auto-config="false" access-decision-manager-ref="accessDecisionManager" entry-point-ref="entryPoint">
         <intercept-url pattern="/reports/**" access="SCOPE_READ" /> <!-- TODO: Break out into finer-grained scopes? -->

--- a/server/api/src/main/webapp/WEB-INF/web.xml
+++ b/server/api/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
     <!-- Java-based annotation-driven Spring container definition -->
     <context-param>

--- a/server/oauth/src/main/java/com/springsource/oauthservice/config/data.xml
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/config/data.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:cloud="http://schema.cloudfoundry.org/spring"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-        http://schema.cloudfoundry.org/spring http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd
-        http://www.springframework.org/schema/cloud http://www.springframework.org/schema/cloud/spring-cloud.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+        http://schema.cloudfoundry.org/spring https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd
+        http://www.springframework.org/schema/cloud https://www.springframework.org/schema/cloud/spring-cloud.xsd">
 
     <cloud:data-source id="dataSource" service-name="tokendb" />
 

--- a/server/oauth/src/main/java/com/springsource/oauthservice/config/oauth.xml
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/config/oauth.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <beans:beans xmlns="http://www.springframework.org/schema/security/oauth2"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/security/oauth2 http://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security/oauth2 https://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<authorization-server client-details-service-ref="clientDetails" token-services-ref="tokenServices">
 		<authorization-code />

--- a/server/oauth/src/main/java/com/springsource/oauthservice/config/security.xml
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/config/security.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <beans:beans xmlns="http://www.springframework.org/schema/security" xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-3.1.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
     <http auto-config="true" access-decision-manager-ref="accessDecisionManager">
         <intercept-url pattern="/oauth/token" access="IS_AUTHENTICATED_ANONYMOUSLY" />

--- a/server/oauth/src/main/webapp/WEB-INF/layouts/tiles.xml
+++ b/server/oauth/src/main/webapp/WEB-INF/layouts/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 

--- a/server/oauth/src/main/webapp/WEB-INF/views/develop/apps/tiles.xml
+++ b/server/oauth/src/main/webapp/WEB-INF/views/develop/apps/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 

--- a/server/oauth/src/main/webapp/WEB-INF/web.xml
+++ b/server/oauth/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
     <!-- Java-based annotation-driven Spring container definition -->
     <context-param>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://10.0.2.2:8080 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://10.0.2.2:8080 ([https](https://10.0.2.2:8080) result ConnectTimeoutException).
* http://debug.phonegap.com (UnknownHostException) with 1 occurrences migrated to:  
  https://debug.phonegap.com ([https](https://debug.phonegap.com) result UnknownHostException).
* http://haboauth.cloudfoundry.com (UnknownHostException) with 1 occurrences migrated to:  
  https://haboauth.cloudfoundry.com ([https](https://haboauth.cloudfoundry.com) result UnknownHostException).
* http://html5expense-api.cloudfoundry.com (UnknownHostException) with 1 occurrences migrated to:  
  https://html5expense-api.cloudfoundry.com ([https](https://html5expense-api.cloudfoundry.com) result UnknownHostException).
* http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd (404) with 1 occurrences migrated to:  
  https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd ([https](https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://tiles.apache.org/dtds/tiles-config_2_1.dtd with 2 occurrences migrated to:  
  https://tiles.apache.org/dtds/tiles-config_2_1.dtd ([https](https://tiles.apache.org/dtds/tiles-config_2_1.dtd) result 200).
* http://www.springframework.org/schema/batch/spring-batch-2.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch-2.1.xsd ([https](https://www.springframework.org/schema/batch/spring-batch-2.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/cloud/spring-cloud.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/spring-cloud.xsd ([https](https://www.springframework.org/schema/cloud/spring-cloud.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security-3.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-3.1.xsd ([https](https://www.springframework.org/schema/security/spring-security-3.1.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd ([https](https://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).
* http://maven.springframework.org/milestone with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release with 1 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot with 1 occurrences migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/javaee with 4 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://schema.cloudfoundry.org/spring with 2 occurrences
* http://schemas.android.com/apk/res/android with 2 occurrences
* http://www.springframework.org/schema/batch with 2 occurrences
* http://www.springframework.org/schema/beans with 12 occurrences
* http://www.springframework.org/schema/cloud with 1 occurrences
* http://www.springframework.org/schema/context with 1 occurrences
* http://www.springframework.org/schema/integration with 2 occurrences
* http://www.springframework.org/schema/security with 4 occurrences
* http://www.springframework.org/schema/security/oauth2 with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 9 occurrences