### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                               Apache License
                         Version 2.0, January 2004
-                     http://www.apache.org/licenses/
+                     https://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/client/shared/www/controller.js
+++ b/client/shared/www/controller.js
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/client/shared/www/device-detection.js
+++ b/client/shared/www/device-detection.js
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/client/shared/www/phonegap-android-1.3.0.js
+++ b/client/shared/www/phonegap-android-1.3.0.js
@@ -7,7 +7,7 @@
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -929,7 +929,7 @@ PhoneGap.includeJavascript = function(jsfile, successCallback) {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -1045,7 +1045,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -1182,7 +1182,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -1284,7 +1284,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -1418,7 +1418,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -1586,7 +1586,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -1785,7 +1785,7 @@ PhoneGap.addConstructor(function(){
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -1938,7 +1938,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -2259,7 +2259,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -2313,7 +2313,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -3318,7 +3318,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -3429,7 +3429,7 @@ var FileUploadOptions = function(fileKey, fileName, mimeType, params) {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -3638,7 +3638,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -3871,7 +3871,7 @@ PhoneGap.Media.onStatus = function(id, msg, value) {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -3971,7 +3971,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -4104,7 +4104,7 @@ PhoneGap.addConstructor(function() {
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an
@@ -4204,7 +4204,7 @@ PositionError.TIMEOUT = 3;
  *     "License"); you may not use this file except in compliance
  *     with the License.  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *     Unless required by applicable law or agreed to in writing,
  *     software distributed under the License is distributed on an

--- a/server/api/src/main/java/com/springsource/html5expense/EligibleCharge.java
+++ b/server/api/src/main/java/com/springsource/html5expense/EligibleCharge.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/Expense.java
+++ b/server/api/src/main/java/com/springsource/html5expense/Expense.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/ExpenseReport.java
+++ b/server/api/src/main/java/com/springsource/html5expense/ExpenseReport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/ExpenseReportingService.java
+++ b/server/api/src/main/java/com/springsource/html5expense/ExpenseReportingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/State.java
+++ b/server/api/src/main/java/com/springsource/html5expense/State.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/config/BatchConfig.java
+++ b/server/api/src/main/java/com/springsource/html5expense/config/BatchConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/config/CloudDataSourceConfig.java
+++ b/server/api/src/main/java/com/springsource/html5expense/config/CloudDataSourceConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/config/ComponentConfig.java
+++ b/server/api/src/main/java/com/springsource/html5expense/config/ComponentConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/config/DataSourceConfig.java
+++ b/server/api/src/main/java/com/springsource/html5expense/config/DataSourceConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/config/LocalDataSourceConfig.java
+++ b/server/api/src/main/java/com/springsource/html5expense/config/LocalDataSourceConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/config/SecurityConfig.java
+++ b/server/api/src/main/java/com/springsource/html5expense/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/config/WebConfig.java
+++ b/server/api/src/main/java/com/springsource/html5expense/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/controllers/ExpenseReportingApiController.java
+++ b/server/api/src/main/java/com/springsource/html5expense/controllers/ExpenseReportingApiController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/controllers/ExpenseReportingViewController.java
+++ b/server/api/src/main/java/com/springsource/html5expense/controllers/ExpenseReportingViewController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/integrations/EligibleChargeProcessor.java
+++ b/server/api/src/main/java/com/springsource/html5expense/integrations/EligibleChargeProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/integrations/EligibleChargeProcessorHeaders.java
+++ b/server/api/src/main/java/com/springsource/html5expense/integrations/EligibleChargeProcessorHeaders.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/security/EndpointTokenServices.java
+++ b/server/api/src/main/java/com/springsource/html5expense/security/EndpointTokenServices.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/security/OAuth2AuthenticationMixin.java
+++ b/server/api/src/main/java/com/springsource/html5expense/security/OAuth2AuthenticationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/services/Flag.java
+++ b/server/api/src/main/java/com/springsource/html5expense/services/Flag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/api/src/main/java/com/springsource/html5expense/services/JpaExpenseReportingService.java
+++ b/server/api/src/main/java/com/springsource/html5expense/services/JpaExpenseReportingService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/Bootstrap.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/Bootstrap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/IdentityController.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/IdentityController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/config/ComponentConfig.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/config/ComponentConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/config/DataConfig.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/config/DataConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/config/SecurityConfig.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/config/WebConfig.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/config/WebConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/develop/App.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/develop/App.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppController.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppForm.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppRepository.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppSummary.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/develop/AppSummary.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/develop/JdbcAppRepository.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/develop/JdbcAppRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/server/oauth/src/main/java/com/springsource/oauthservice/utils/SlugUtils.java
+++ b/server/oauth/src/main/java/com/springsource/oauthservice/utils/SlugUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 54 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).